### PR TITLE
Update cleanup.sh

### DIFF
--- a/src/centos-7-x64/scripts/cleanup.sh
+++ b/src/centos-7-x64/scripts/cleanup.sh
@@ -46,4 +46,4 @@ unset HISTFILE
 #Remove the root user’s SSH history & other cruft
 /bin/rm -rf ~root/.ssh/
 /bin/rm -f ~root/anaconda-ks.cfg
-
+rm -f /etc/redhat-release && touch /etc/redhat-release && echo 'Red Hat Enterprise Linux Server release 7.0 (Maipo)' > /etc/redhat-release


### PR DESCRIPTION
should fix centos7 working with open-tools